### PR TITLE
`[duckdb-0.8.1]` Toward

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,6 @@
 {:paths ["src"]
- :deps {techascent/tech.ml.dataset {:mvn/version "6.046"}
-        techascent/tech.ml.dataset.sql {:mvn/version "6.046-01"}
+ :deps {techascent/tech.ml.dataset {:mvn/version "7.000-beta-52"}
+        techascent/tech.ml.dataset.sql {:mvn/version "7.000-beta-52"}
         net.java.dev.jna/jna {:mvn/version "5.9.0"}}
  :aliases
  {:depstar

--- a/scripts/enable-duckdb
+++ b/scripts/enable-duckdb
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ ! -e binaries ]; then
-    wget https://github.com/duckdb/duckdb/releases/download/v0.3.1/libduckdb-linux-amd64.zip
+    wget https://github.com/duckdb/duckdb/releases/download/v0.8.1/libduckdb-linux-amd64.zip
     unzip libduckdb-linux-amd64.zip -d binaries
     rm libduckdb-linux-amd64.zip
 fi


### PR DESCRIPTION
```
harold@freeside:~/src/tmducken [duckdb-0.8.1]$ ./scripts/run-tests 

Running tests in #{"test"}
13:42:22.513 [main] INFO  tmducken.duckdb - Attempting to load duckdb from "/home/harold/src/tmducken/binaries/libduckdb.so"

Testing tmducken.duckdb-test
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by tech.v3.datatype.UnsafeUtil (file:/home/harold/.m2/repository/cnuernber/dtype-next/10.000-beta-51/dtype-next-10.000-beta-51.jar) to constructor java.nio.DirectByteBuffer(long,int)
WARNING: Please consider reporting this to the maintainers of tech.v3.datatype.UnsafeUtil
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
```

This got surprisingly far before these "illegal reflective access operation" warnings...

Then the tests fail, because the result set has no rows (afaict) ... not sure if that's because they failed to be inserted, or because they failed to be returned, or?

Perhaps we should also fork this into a techascent repo? Or perhaps add me as a contributor on your fork?