### PR TITLE
Updated code to work with duckdb 0.8.1

### DIFF
--- a/scripts/enable-duckdb
+++ b/scripts/enable-duckdb
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ ! -e binaries ]; then
-    wget https://github.com/duckdb/duckdb/releases/download/v0.3.1/libduckdb-linux-amd64.zip
+    wget https://github.com/duckdb/duckdb/releases/download/v0.8.1/libduckdb-linux-amd64.zip
     unzip libduckdb-linux-amd64.zip -d binaries
     rm libduckdb-linux-amd64.zip
 fi

--- a/src/tmducken/duckdb/ffi.clj
+++ b/src/tmducken/duckdb/ffi.clj
@@ -280,6 +280,26 @@ all memory associated with the appender.
     :duckdb_destroy_result {:rettype :void
                             :argtypes [[result :pointer]]}
 
+    ;; result functions
+    :duckdb_row_count {:rettype :int32
+                       :argtypes [[result :pointer]]}
+    :duckdb_column_count {:rettype :int32
+                          :argtypes [[result :pointer]]}
+
+    ;; column functions
+    :duckdb_column_name {:rettype :pointer
+                         :argtypes [[result :pointer]
+                                    [col :int64]]}
+    :duckdb_column_data {:rettype :int64
+                         :argtypes [[result :pointer]
+                                    [col :int64]]}
+    :duckdb_nullmask_data {:rettype :int64
+                           :argtypes [[result :pointer]
+                                      [col :int64]]}
+    :duckdb_column_type {:rettype :int32
+                         :argtypes [[result :pointer]
+                                    [col :int64]]}
+
     ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
     ;; Prepared Statements
     ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
When using duckdb 0.8.1, the `:row-count` field of the result-set struct is always 0, possible because of [this change](https://github.com/duckdb/duckdb/pull/2864)

We need to use `duckdb_row_count` `duckdb_column_data` etc. to access the result set instead of directly accessing its internal struct.

