### PR TITLE
`[test]` failing insert test

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,7 @@
 {:paths ["src"]
  :deps {techascent/tech.ml.dataset {:mvn/version "7.006"}
         techascent/tech.ml.dataset.sql {:mvn/version "7.000-beta-52"}
+        cnuernber/dtype-next {:mvn/version "10.011"}
         net.java.dev.jna/jna {:mvn/version "5.13.0"}}
  :aliases
  {:build

--- a/deps.edn
+++ b/deps.edn
@@ -24,7 +24,7 @@
    :exec-fn codox.main/-main
    :exec-args {:group-id "com.techascent"
                :artifact-id "tmducken"
-               :version "0.8.1-11"
+               :version "0.8.1-12-SNAPSHOT"
                :name "TMDucken"
                :description "Clojure bindings for duckdb"
                :metadata {:doc/format :markdown}

--- a/src/tmducken/duckdb.clj
+++ b/src/tmducken/duckdb.clj
@@ -405,30 +405,30 @@ tmducken.duckdb> (get-config-options)
                    (:string :text)
                    (let [stable (hamf/java-concurrent-hashmap)
                          nbuf (wrap-addr daddr (* 16 row-count) :int8)]
-                     (hamf/pgroups row-count
-                                   (fn [^long sidx ^long eidx]
-                                     (let [ne (- eidx sidx)]
-                                       (dotimes [idx ne]
-                                         (let [idx (+ sidx idx)
-                                               sval (str (subcol idx))]
-                                           (if-let [init-addr (.get stable sval)]
-                                             (dt/copy! (wrap-addr init-addr 16 :uint8)
-                                                       (dt/sub-buffer nbuf (* 16 idx) 16))
-                                             (let [bval (.getBytes sval)
-                                                   slen (alength bval)
-                                                   bufoff (* 16 idx)]
-                                               (native-buffer/write-int nbuf bufoff slen)
-                                               (if (<= slen 12)
-                                                 (let [bufoff (+ bufoff 4)]
-                                                   (dt/copy! bval (dt/sub-buffer nbuf bufoff slen)))
-                                                 (let [bufoff (+ bufoff 8)
-                                                       valbuf (native-buffer/malloc slen {:resource-type nil
-                                                                                          :uninitialized? true})
-                                                       _ (locking string-allocs (.add string-allocs valbuf))
-                                                       bufaddr (ptr->addr valbuf)]
-                                                   (dt/copy! bval valbuf)
-                                                   (native-buffer/write-long nbuf bufoff bufaddr)))
-                                               (.put stable sval (+ daddr bufoff)))))))))))))
+                     (dorun (hamf/pgroups row-count
+                                          (fn [^long sidx ^long eidx]
+                                            (let [ne (- eidx sidx)]
+                                              (dotimes [idx ne]
+                                                (let [idx (+ sidx idx)
+                                                      sval (str (subcol idx))]
+                                                  (if-let [init-addr (.get stable sval)]
+                                                    (dt/copy! (wrap-addr init-addr 16 :uint8)
+                                                              (dt/sub-buffer nbuf (* 16 idx) 16))
+                                                    (let [bval (.getBytes sval)
+                                                          slen (alength bval)
+                                                          bufoff (* 16 idx)]
+                                                      (native-buffer/write-int nbuf bufoff slen)
+                                                      (if (<= slen 12)
+                                                        (let [bufoff (+ bufoff 4)]
+                                                          (dt/copy! bval (dt/sub-buffer nbuf bufoff slen)))
+                                                        (let [bufoff (+ bufoff 8)
+                                                              valbuf (native-buffer/malloc slen {:resource-type nil
+                                                                                                 :uninitialized? true})
+                                                              _ (locking string-allocs (.add string-allocs valbuf))
+                                                              bufaddr (ptr->addr valbuf)]
+                                                          (dt/copy! bval valbuf)
+                                                          (native-buffer/write-long nbuf bufoff bufaddr)))
+                                                      (.put stable sval (+ daddr bufoff))))))))))))))
              (check-error (duckdb-ffi/duckdb_append_data_chunk appender write-chunk))
              (duckdb-ffi/duckdb_data_chunk_reset write-chunk))))
         n-rows

--- a/test/tmducken/duckdb_test.clj
+++ b/test/tmducken/duckdb_test.clj
@@ -135,24 +135,23 @@
         (catch Throwable e nil)))))
 
 (deftest insert-test
-  (println "========================================")
-  (println "insert-test")
+  #_(println "========================================")
+  #_(println "insert-test")
   (let [cn 4
         rn 1024
         ds-fn #(-> (into {} (for [i (range cn)] [(str "c" i)
                                                  (for [_ (range rn)] (str (random-uuid)))]))
                    (ds/->dataset {:dataset-name "t"})
                    (ds/select-columns (for [i (range cn)] (str "c" i))))]
-    (println "drop-table!")
+    #_(println "drop-table!")
     (try
       (duckdb/drop-table! @conn* "t")
       (catch Throwable e nil))
-    (println "create-table!")
     (duckdb/create-table! @conn* (ds-fn))
-    (println "insert-dataset! (first)")
+    #_(println "insert-dataset! (first)")
     (duckdb/insert-dataset! @conn* (ds-fn))
-    (println "insert-dataset! (second)")
+    #_(println "insert-dataset! (second)")
     (duckdb/insert-dataset! @conn* (ds-fn))
-    (println "insert-dataset! (sql->dataset)")
+    #_(println "insert-dataset! (sql->dataset)")
     (is (= (* 2 rn) (-> (duckdb/sql->dataset @conn* "from t")
                         (ds/row-count))))))


### PR DESCRIPTION
 - Note, if rn=8, then it works fine

@cnuernber - here is the crash I'm seeing:

```
$ ./scripts/run-tests 

Running tests in #{"test"}
11:27:53.215 [main] INFO  tmducken.duckdb - Attempting to load duckdb from "/home/harold/src/tmducken/binaries/libduckdb.so"

Testing tmducken.duckdb-test
========================================
insert-test
drop-table!
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by tech.v3.datatype.UnsafeUtil (file:/home/harold/.m2/repository/cnuernber/dtype-next/10.010/dtype-next-10.010.jar) to constructor java.nio.DirectByteBuffer(long,int)
WARNING: Please consider reporting this to the maintainers of tech.v3.datatype.UnsafeUtil
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
create-table!
insert-dataset! (first)
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  SIGSEGV (0xb) at pc=0x00007f0c2e3aef4d, pid=95651, tid=95660
#
# JRE version: OpenJDK Runtime Environment (11.0.20.1+1) (build 11.0.20.1+1-post-Ubuntu-0ubuntu122.04)
# Java VM: OpenJDK 64-Bit Server VM (11.0.20.1+1-post-Ubuntu-0ubuntu122.04, mixed mode, sharing, tiered, compressed oops, g1 gc, linux-amd64)
# Problematic frame:
# C  [libc.so.6+0x1aef4d]
#
# Core dump will be written. Default location: Core dumps may be processed with "/usr/share/apport/apport -p%p -s%s -c%c -d%d -P%P -u%u -g%g -- %E" (or dumping to /home/harold/src/tmducken/core.95651)
#
# An error report file with more information is saved as:
# /home/harold/src/tmducken/hs_err_pid95651.log
#
# If you would like to submit a bug report, please visit:
#   https://bugs.launchpad.net/ubuntu/+source/openjdk-lts
# The crash happened outside the Java Virtual Machine in native code.
# See problematic frame for where to report the bug.
#
rlwrap: warning: clojure crashed, killed by SIGABRT (core dumped).
rlwrap itself has not crashed, but for transparency,
it will now kill itself with the same signal


warnings can be silenced by the --no-warnings (-n) option
./scripts/run-tests: line 6: 95650 Aborted                 (core dumped) clj -M:test
```