### PR TITLE
fix: error reporting on prepared statements

### DIFF
--- a/src/tmducken/duckdb.clj
+++ b/src/tmducken/duckdb.clj
@@ -1111,7 +1111,7 @@ _unnamed [5 3]:
          stmt (Pointer. (long (stmt-ptr 0)))
          _   (when-not (== 0 tval)
                (let [errptr (duckdb-ffi/duckdb_prepare_error stmt)
-                     errors (when errptr
+                     errors (if errptr
                               (dt-ffi/c->string errptr)
                               "Unknown Error")]
                  @destroy-prep*


### PR DESCRIPTION
Fixes an error where we would return an `Unknown Error` when we actually could determine the error.

This makes debugging SQL statements *much* easier.