### PR TITLE
Update typemap for Duckdb v0.10.1

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1702929109,
-        "narHash": "sha256-k5DGTFzkto/8xlY1B32441Jtp/VCgakzdmieB9HLMWw=",
+        "lastModified": 1711197542,
+        "narHash": "sha256-RMM+G49X56W8gE2sg08TUsuR30KcU0LNLttsSRgxTCM=",
         "owner": "jlesquembre",
         "repo": "clj-nix",
-        "rev": "26cee183a691cabd113b0751a09ad6f381e6681f",
+        "rev": "20109727c6623b486d37fbd957d64c2a8232ccde",
         "type": "github"
       },
       "original": {
@@ -172,11 +172,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1709961763,
-        "narHash": "sha256-6H95HGJHhEZtyYA3rIQpvamMKAGoa8Yh2rFV29QnuGw=",
+        "lastModified": 1712122226,
+        "narHash": "sha256-pmgwKs8Thu1WETMqCrWUm0CkN1nmCKX3b51+EXsAZyY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3030f185ba6a4bf4f18b87f345f104e6a6961f34",
+        "rev": "08b9151ed40350725eb40b1fe96b0b86304a654b",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -45,6 +45,7 @@
             # provides deps-lock library for updating deps-lock.json from deps.edn
             clj-nix.packages.${system}.deps-lock
             pkgs.clojure
+            pkgs.duckdb
           ];
           shellHook = postPatch;
         };

--- a/src/tmducken/duckdb.clj
+++ b/src/tmducken/duckdb.clj
@@ -96,12 +96,9 @@ _unnamed [5 3]:
 
 (defn- check-lib-version!
   []
-  (let [lib-version (duckdb-library-version)
-        parts (.split lib-version "\\.")
-        mid-part (Integer/parseInt (aget parts 1))]
-    (when-not (or (not= "v0" (aget parts 0))
-                  (>= mid-part 10))
-      (throw (RuntimeException. (str "Invalid version: " lib-version " - " "this version of tmducken is meant for duckdb version 0.10.0 and up"))))
+  (let [lib-version (duckdb-library-version)]
+    (when (= lib-version "v0.10.0")
+      (throw (RuntimeException. (str "Invalid version: " lib-version " - " "this version of tmducken is meant for duckdb version 0.10.1 and up but should also work with 0.9.2"))))
     :ok))
 
 

--- a/src/tmducken/duckdb/ffi.clj
+++ b/src/tmducken/duckdb/ffi.clj
@@ -8,57 +8,52 @@
            [tech.v3.datatype.ffi Pointer]))
 
 
+(def ^:private -DUCKDB-TYPES
+  '{DUCKDB_TYPE_INVALID      0
+    DUCKDB_TYPE_BOOLEAN      1
+    DUCKDB_TYPE_TINYINT      2
+    DUCKDB_TYPE_SMALLINT     3
+    DUCKDB_TYPE_INTEGER      4
+    DUCKDB_TYPE_BIGINT       5
+    DUCKDB_TYPE_UTINYINT     6
+    DUCKDB_TYPE_USMALLINT    7
+    DUCKDB_TYPE_UINTEGER     8
+    DUCKDB_TYPE_UBIGINT      9
+    DUCKDB_TYPE_FLOAT        10
+    DUCKDB_TYPE_DOUBLE       11
+    DUCKDB_TYPE_TIMESTAMP    12
+    DUCKDB_TYPE_DATE         13
+    DUCKDB_TYPE_TIME         14
+    DUCKDB_TYPE_INTERVAL     15
+    DUCKDB_TYPE_HUGEINT      16
+    DUCKDB_TYPE_UHUGEINT     32
+    DUCKDB_TYPE_VARCHAR      17
+    DUCKDB_TYPE_BLOB         18
+    DUCKDB_TYPE_DECIMAL      19
+    DUCKDB_TYPE_TIMESTAMP_S  20
+    DUCKDB_TYPE_TIMESTAMP_MS 21
+    DUCKDB_TYPE_TIMESTAMP_NS 22
+    DUCKDB_TYPE_ENUM         23
+    DUCKDB_TYPE_LIST         24
+    DUCKDB_TYPE_STRUCT       25
+    DUCKDB_TYPE_MAP          26
+    DUCKDB_TYPE_UUID         27
+    DUCKDB_TYPE_UNION        28
+    DUCKDB_TYPE_BIT          29
+    DUCKDB_TYPE_TIME_TZ      30
+    DUCKDB_TYPE_TIMESTAMP_TZ 31})
+
 (defmacro define-long-enums
   []
-  (let [[stmts offset typemap]
-        (->>
-        '[[DUCKDB_TYPE_INVALID 0] ;;starts at zero
-	  DUCKDB_TYPE_BOOLEAN
-	  DUCKDB_TYPE_TINYINT
-	  DUCKDB_TYPE_SMALLINT
-	  DUCKDB_TYPE_INTEGER
-	  DUCKDB_TYPE_BIGINT
-	  DUCKDB_TYPE_UTINYINT
-	  DUCKDB_TYPE_USMALLINT
-	  DUCKDB_TYPE_UINTEGER
-	  DUCKDB_TYPE_UBIGINT
-	  DUCKDB_TYPE_FLOAT
-	  DUCKDB_TYPE_DOUBLE
-	  DUCKDB_TYPE_TIMESTAMP
-	  DUCKDB_TYPE_DATE
-	  DUCKDB_TYPE_TIME
-	  DUCKDB_TYPE_INTERVAL
-	  DUCKDB_TYPE_HUGEINT
-	  DUCKDB_TYPE_UHUGEINT
-	  DUCKDB_TYPE_VARCHAR
-	  DUCKDB_TYPE_BLOB
-	  DUCKDB_TYPE_DECIMAL
-	  DUCKDB_TYPE_TIMESTAMP_S
-	  DUCKDB_TYPE_TIMESTAMP_MS
-	  DUCKDB_TYPE_TIMESTAMP_NS
-	  DUCKDB_TYPE_ENUM
-	  DUCKDB_TYPE_LIST
-	  DUCKDB_TYPE_STRUCT
-	  DUCKDB_TYPE_MAP
-	  DUCKDB_TYPE_UUID
-	  DUCKDB_TYPE_UNION
-	  DUCKDB_TYPE_BIT
-	  DUCKDB_TYPE_TIME_TZ
-	  DUCKDB_TYPE_TIMESTAMP_TZ]
-        (reduce (fn [[stmts offset typemap] entry]
-                  (let [offset (if (vector? entry)
-                                 (second entry)
-                                 (inc offset))
-                        sym (if (vector? entry)
-                              (first entry)
-                              entry)]
-                    [(conj stmts `(def ~(with-meta sym {:tag 'long}) ~offset)) offset
-                     (assoc typemap offset (keyword (name sym)))]))
-                ;;enums start at 0 and increment
-                [[] -1 {}]))] 
-    `(do
-       ~@stmts
-       (def duckdb-type-map ~typemap))))
+  (let [sym-defs     (for [[sym-name val] -DUCKDB-TYPES]
+                       `(def ~(with-meta sym-name {:tag 'long}) ~val))
+        type-map-def (reduce
+                       (fn [type-map-def [sym-name val]]
+                         (assoc type-map-def val (keyword sym-name)))
+                       {}
+                       -DUCKDB-TYPES)]
+    `(do ~@sym-defs
+         (def duckdb-type-map ~type-map-def))))
 
 (define-long-enums)
 


### PR DESCRIPTION
This commit reverts the breaking type mapping definitions that the duckdb team introduced in `v0.10.0` and switches them to how they do them in `v0.10.1` / `v0.9.2`. ie. They realized that they broke all C-based APIs and undid the UHUGEINT insertion.

In here is also a bit of a refactor that tries to get some of the DRYness of the `define-long-enums` while also mimicking  the new style of the C api (where they use explicit mappings on enums). See [this pull request](https://github.com/duckdb/duckdb/pull/10649) for details. I think this strikes a nice balance between clarity and DRYness.

Lastly we now only error on version `v0.10.0` since this should restore compatibility with `v0.9.2`. I confirmed that the test suite passes when using duckdb `v0.9.2` via nix flakes.