### PR TITLE
fix: pivot table and multi-statement support

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1711197542,
-        "narHash": "sha256-RMM+G49X56W8gE2sg08TUsuR30KcU0LNLttsSRgxTCM=",
+        "lastModified": 1713172900,
+        "narHash": "sha256-1HPffCAfi8PWbf8zcxmMR+Zfp5mqz4LtBYLOr8pL/2o=",
         "owner": "jlesquembre",
         "repo": "clj-nix",
-        "rev": "20109727c6623b486d37fbd957d64c2a8232ccde",
+        "rev": "2223155bdea15736ee1be7a9cc3dc33fd8ef1e44",
         "type": "github"
       },
       "original": {
@@ -172,11 +172,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1712122226,
-        "narHash": "sha256-pmgwKs8Thu1WETMqCrWUm0CkN1nmCKX3b51+EXsAZyY=",
+        "lastModified": 1713248628,
+        "narHash": "sha256-NLznXB5AOnniUtZsyy/aPWOk8ussTuePp2acb9U+ISA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "08b9151ed40350725eb40b1fe96b0b86304a654b",
+        "rev": "5672bc9dbf9d88246ddab5ac454e82318d094bb8",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -25,7 +25,7 @@
         # Definining a reusable DLL providing script, used for Nix repeatable build AND direnv shell entering (development)
         postPatch = ''
           mkdir -p ${lib-folder}
-          ln -sf ${pkgs.duckdb}/lib/* ${lib-folder}
+          ln -sf ${pkgs.duckdb.lib}/lib/* ${lib-folder}
         '';
       in {
 

--- a/src/tmducken/duckdb/ffi.clj
+++ b/src/tmducken/duckdb/ffi.clj
@@ -330,10 +330,10 @@ all memory associated with the appender.
 
     ;; DUCKDB_API const char *duckdb_prepare_error(duckdb_prepared_statement prepared_statement);
     :duckdb_prepare_error {:rettype :pointer?
-                           :argtypes [[prepared-statement :pointer]]}
+                           :argtypes [[prepared-statement (by-value :duckdb-prepared-statement)]]}
     ;; DUCKDB_API idx_t duckdb_nparams(duckdb_prepared_statement prepared_statement);
     :duckdb_nparams {:rettype :int64
-                     :argtypes [[prepared-statement :pointer]]}
+                     :argtypes [[prepared-statement (by-value :duckdb-prepared-statement)]]}
     ;; DUCKDB_API duckdb_type duckdb_param_type(duckdb_prepared_statement prepared_statement, idx_t param_idx);
     :duckdb_param_type {:rettype :int32
                         :argtypes [[prepared-statement :pointer]
@@ -343,76 +343,95 @@ all memory associated with the appender.
                             :argtypes [[prepared-statement :pointer]]}
     ;; DUCKDB_API duckdb_state duckdb_bind_boolean(duckdb_prepared_statement prepared_statement, idx_t param_idx, bool val);
     :duckdb_bind_boolean {:rettype :int32
-                          :argtypes [[prepared-statement :pointer]
+                          :argtypes [[prepared-statement (by-value :duckdb-prepared-statement)]
                                      [param-idx :int64]
                                      [val :int8]]}
     ;; DUCKDB_API duckdb_state duckdb_bind_int8(duckdb_prepared_statement prepared_statement, idx_t param_idx, int8_t val);
     :duckdb_bind_int8 {:rettype :int32
-                       :argtypes [[prepared-statement :pointer]
+                       :argtypes [[prepared-statement (by-value :duckdb-prepared-statement)]
                                   [param-idx :int64]
                                   [val :int8]]}
     :duckdb_bind_int16 {:rettype :int32
-                        :argtypes [[prepared-statement :pointer]
+                        :argtypes [[prepared-statement (by-value :duckdb-prepared-statement)]
                                    [param-idx :int64]
                                    [val :int16]]}
     :duckdb_bind_int32 {:rettype :int32
-                        :argtypes [[prepared-statement :pointer]
+                        :argtypes [[prepared-statement (by-value :duckdb-prepared-statement)]
                                    [param-idx :int64]
                                    [val :int32]]}
     :duckdb_bind_int64 {:rettype :int32
-                        :argtypes [[prepared-statement :pointer]
+                        :argtypes [[prepared-statement (by-value :duckdb-prepared-statement)]
                                    [param-idx :int64]
                                    [val :int64]]}
     :duckdb_bind_uint8 {:rettype :int32
-                        :argtypes [[prepared-statement :pointer]
+                        :argtypes [[prepared-statement (by-value :duckdb-prepared-statement)]
                                    [param-idx :int64]
                                    [val :int8]]}
     :duckdb_bind_uint16 {:rettype :int32
-                         :argtypes [[prepared-statement :pointer]
+                         :argtypes [[prepared-statement (by-value :duckdb-prepared-statement)]
                                     [param-idx :int64]
                                     [val :int16]]}
     :duckdb_bind_uint32 {:rettype :int32
-                         :argtypes [[prepared-statement :pointer]
+                         :argtypes [[prepared-statement (by-value :duckdb-prepared-statement)]
                                     [param-idx :int64]
                                     [val :int32]]}
     :duckdb_bind_uint64 {:rettype :int32
-                         :argtypes [[prepared-statement :pointer]
+                         :argtypes [[prepared-statement (by-value :duckdb-prepared-statement)]
                                     [param-idx :int64]
                                     [val :int64]]}
 
     :duckdb_bind_float {:rettype :int32
-                        :argtypes [[prepared-statement :pointer]
+                        :argtypes [[prepared-statement (by-value :duckdb-prepared-statement)]
                                    [param-idx :int64]
                                    [val :float32]]}
     :duckdb_bind_double {:rettype :int32
-                         :argtypes [[prepared-statement :pointer]
+                         :argtypes [[prepared-statement (by-value :duckdb-prepared-statement)]
                                     [param-idx :int64]
                                     [val :float64]]}
     :duckdb_bind_date {:rettype :int32
-                       :argtypes [[prepared-statement :pointer]
+                       :argtypes [[prepared-statement (by-value :duckdb-prepared-statement)]
                                   [param-idx :int64]
                                   [val :int32]]}
     :duckdb_bind_time {:rettype :int32
-                       :argtypes [[prepared-statement :pointer]
+                       :argtypes [[prepared-statement (by-value :duckdb-prepared-statement)]
                                   [param-idx :int64]
                                   [val :int64]]}
 
     :duckdb_bind_timestamp {:rettype :int32
-                            :argtypes [[prepared-statement :pointer]
+                            :argtypes [[prepared-statement (by-value :duckdb-prepared-statement)]
                                        [param-idx :int64]
                                        [val :int64]]}
     ;; DUCKDB_API duckdb_state duckdb_bind_varchar_length(duckdb_prepared_statement prepared_statement, idx_t param_idx,
     ;;                                                                              const char *val, idx_t length);
     :duckdb_bind_varchar_length {:rettype :int32
-                                 :argtypes [[prepared-statement :pointer]
+                                 :argtypes [[prepared-statement (by-value :duckdb-prepared-statement)]
                                             [param-idx :int64]
                                             [val :pointer]
                                             [length :int64]]}
 
     :duckdb_bind_null {:rettype :int32
-                       :argtypes [[prepared-statement :pointer]
+                       :argtypes [[prepared-statement (by-value :duckdb-prepared-statement)]
                                   [param-idx :int64]]}
 
+    :duckdb_result_statement_type {:rettype :int32
+                                   :argtypes [[result (by-value :duckdb-result)]]}
+    :duckdb_extract_statements {:rettype :int64
+                                :argtypes [[connection :pointer]
+                                           [query :string]
+                                           [out-extracted-statements :pointer]]}
+    :duckdb_prepare_extracted_statement {:rettype :int32
+                                         :argtypes [[connection :pointer]
+                                                    [statement (by-value :duckdb-extracted-statements)]
+                                                    [statement-idx :int64]
+                                                    [out-prepared-statement :pointer]]}
+    :duckdb_extract_statements_error {:rettype  :pointer?
+                                      :argtypes [[statements (by-value :duckdb-extracted-statements)]]}
+    :duckdb_destroy_extracted {:rettype :void
+                               :argtypes [[extracted-statements :pointer]]}
+    :duckdb_result_return_type {:rettype :int32
+                                :argtypes [[result (by-value :duckdb-result)]]}
+    :duckdb_prepared_statement_type {:rettype :int32
+                                     :argtypes [[statement (by-value :duckdb-prepared-statement)]]}
 
     ;; ;; DUCKDB_API duckdb_state duckdb_bind_hugeint(duckdb_prepared_statement prepared_statement, idx_t param_idx,
     ;; ;;                                                                       duckdb_hugeint val);
@@ -435,29 +454,28 @@ all memory associated with the appender.
     ;; ;; DUCKDB_API duckdb_state duckdb_pending_prepared(duckdb_prepared_statement prepared_statement,
     ;; ;;                                                                           duckdb_pending_result *out_result);
     :duckdb_pending_prepared {:rettype :int32
-                              :argtypes [[prepared-statement :pointer]
+                              :argtypes [[prepared-statement (by-value :duckdb-prepared-statement)]
                                          [out-pending-result :pointer]]}
     ;; ;; DUCKDB_API duckdb_state duckdb_pending_prepared_streaming(duckdb_prepared_statement prepared_statement,
     ;; ;;                                                                                     duckdb_pending_result *out_result);
     :duckdb_pending_prepared_streaming {:rettype :int32
-                                        :argtypes [[prepared-statement :pointer]
+                                        :argtypes [[prepared-statement (by-value :duckdb-prepared-statement)]
                                                    [out-pending-result :pointer]]}
     ;; ;; DUCKDB_API void duckdb_destroy_pending(duckdb_pending_result *pending_result);
     :duckdb_destroy_pending {:rettype :void
                              :argtypes [[pending-result :pointer]]}
     :duckdb_pending_error {:rettype :pointer?
-                           :argtypes [[pending-result :pointer]]}
+                           :argtypes [[pending-result (by-value :duckdb-pending-result)]]}
     ;; ;; DUCKDB_API const char *duckdb_pending_error(duckdb_pending_result pending_result);
     ;; ;; DUCKDB_API duckdb_pending_state duckdb_pending_execute_task(duckdb_pending_result pending_result);
     ;; ;; DUCKDB_API duckdb_state duckdb_execute_pending(duckdb_pending_result pending_result, duckdb_result *out_result);
     :duckdb_execute_pending {:rettype :int32
-                             :argtypes [[pending-result :pointer]
+                             :argtypes [[pending-result (by-value :duckdb-pending-result)]
                                         [duckdb-result :pointer]]}
 
     ;;DUCKDB_API duckdb_data_chunk duckdb_stream_fetch_chunk(duckdb_result result);
     :duckdb_stream_fetch_chunk {:rettype :pointer?
-                                :argtypes [[result (by-value :duckdb-result)]]}
-    }
+                                :argtypes [[result (by-value :duckdb-result)]]}}
   nil
   nil)
 


### PR DESCRIPTION
This commit introduces support for pivot tables by adding support for multiple statements inside a prepared statement. This is because a pivot table will automatically create an anonymous type for the result before running.

This commit includes several refactors to help cleanup the code.

1) Updates the duckdb-ffi function defenitions by changing `:pointer` to `by-value :type` defenitions. This allows the use of resource tracking on the structs to call the cleanup functions, as well as allowing the structs to be passed as `:pointer` when approprirate (avoiding a lot of the manual `Pointer.` construction) via the auto casting of `->pointer`.

2) Get rid of the multiple types for `PrepStatement` arities and instead just defenining multiple `IFn` impls for the various arities.

3) Get rid of the `param-types` vector which wasn't being used in the current version of param binding.

4) Get rid of the need to destroy resources manually and instead rely on the resource tracking.

5) Introduce a `->error` fn helper for generating error messages from c-string ptrs since we had a lot of code that was doing the required ceremony inline.

6) Introduce a `-execute-stmt!` helper that handles resource binding and cleanup to make it easier to understand the logic inside `prepare!`

One thing of note is that the `AutoClosable` implementation doesn't explicitly free the result anymore. We now instead wait for the GC to get rid of it. If you prefer that I also release them on `AutoClosable` it's relatively easy to support both. Right now the AutoClosable impl is a `no-op` effectively.